### PR TITLE
✨ 重构collections.yaml数据结构：拆分日期字段为start_date和end_date

### DIFF
--- a/src/components/ListCollections.vue
+++ b/src/components/ListCollections.vue
@@ -25,6 +25,13 @@ function getStatusLabel(status: string) {
 function formatName(name: string) {
   return name.split('_')
 }
+
+function formatDate(item: any) {
+  if (item.status === 'completed' && item.end_date) {
+    return `${item.start_date} - ${item.end_date}`
+  }
+  return item.start_date || item.date // 向后兼容旧的date字段
+}
 </script>
 
 <template>
@@ -71,7 +78,7 @@ function formatName(name: string) {
               </template>
             </div>
             <div class="date text-xs op50">
-              {{ item.date }}
+              {{ formatDate(item) }}
             </div>
             <div v-if="getStatusLabel(item.status)" class="status text-xs mt-0.5" :class="getStatusLabel(item.status)?.class">
               {{ getStatusLabel(item.status)?.text }}

--- a/src/components/ListCollections.vue
+++ b/src/components/ListCollections.vue
@@ -1,7 +1,15 @@
 <script setup lang="ts">
 import collectionsData from '~/data/collections.yaml'
 
-const collections = collectionsData as Record<string, any[]>
+interface CollectionItem {
+  name: string
+  cover: string
+  status: 'completed' | 'in_progress' | 'wishlist'
+  start_date: string
+  end_date?: string
+}
+
+const collections = collectionsData as Record<string, CollectionItem[]>
 
 const sortedYears = computed(() => {
   return Object.keys(collections).sort((a, b) => Number(b) - Number(a))
@@ -26,11 +34,11 @@ function formatName(name: string) {
   return name.split('_')
 }
 
-function formatDate(item: any) {
-  if (item.status === 'completed' && item.end_date) {
+function formatDate(item: CollectionItem) {
+  if (item.status === 'completed' && item.end_date)
     return `${item.start_date} - ${item.end_date}`
-  }
-  return item.start_date || item.date // 向后兼容旧的date字段
+
+  return item.start_date
 }
 </script>
 

--- a/src/data/collections.yaml
+++ b/src/data/collections.yaml
@@ -3,34 +3,36 @@
 # 字段说明:
 #   name: 名称（使用 _ 分隔可换行显示）
 #   cover: 封面图片路径（/images/collections/{year}/{number}.jpg）
-#   date: 日期（YYYY-MM-DD）
+#   start_date: 开始日期（YYYY-MM-DD）
+#   end_date: 结束日期（YYYY-MM-DD，可选，仅completed状态有）
 #   status: 状态
-#     - completed: 已完成（不显示标签）
-#     - in_progress: 进行中（蓝色标签）
-#     - wishlist: 想看/想读（橙色标签）
+#     - completed: 已完成（显示日期范围）
+#     - in_progress: 进行中（显示开始日期）
+#     - wishlist: 想看/想读（显示添加日期）
 
 2026:
   - name: 辉夜大小姐想让我告白_通往大人的阶梯
     cover: /images/collections/2026/001.jpg
-    date: 2026-01-01
+    start_date: 2025-12-28
+    end_date: 2026-01-01
     status: completed
   - name: 架构整洁之道
     cover: /images/collections/2026/002.jpg
-    date: 2026-01-01
+    start_date: 2026-01-01
     status: in_progress
   - name: 怪奇物语 第五季
     cover: /images/collections/2026/003.jpg
-    date: 2026-01-03
+    start_date: 2026-01-03
     status: in_progress
   - name: The Immortal Man
     cover: /images/collections/2026/004.jpg
-    date: 2026-03-06
+    start_date: 2026-03-06
     status: wishlist
   - name: 小丑回魂：欢迎来到德里镇
     cover: /images/collections/2026/005.jpg
-    date: 2026-01-02
+    start_date: 2026-01-02
     status: in_progress
   - name: 四元馆事件
     cover: /images/collections/2026/006.jpg
-    date: 2026-01-03
+    start_date: 2026-01-03
     status: wishlist

--- a/src/data/collections.yaml
+++ b/src/data/collections.yaml
@@ -13,7 +13,7 @@
 2026:
   - name: 辉夜大小姐想让我告白_通往大人的阶梯
     cover: /images/collections/2026/001.jpg
-    start_date: 2025-12-28
+    start_date: 2026-01-01
     end_date: 2026-01-01
     status: completed
   - name: 架构整洁之道
@@ -35,4 +35,4 @@
   - name: 四元馆事件
     cover: /images/collections/2026/006.jpg
     start_date: 2026-01-03
-    status: wishlist
+    status: in_progress


### PR DESCRIPTION
## 📝 修改说明

本PR重构了`collections.yaml`的数据结构，将单一的`date`字段拆分为`start_date`和`end_date`字段，以提供更丰富的日期信息。

## 🔧 主要修改

### 📊 数据结构变更
- **旧的结构**：
  ```yaml
  date: 2026-01-01
  ```
  
- **新的结构**：
  ```yaml
  start_date: 2026-01-01  # 开始日期
  end_date: 2026-01-05    # 结束日期（仅completed状态可选）
  ```

### 🎯 具体修改内容

#### 1. 数据文件更新 (`src/data/collections.yaml`)
- 📚 **已完成项目** (`completed`): 添加`start_date`和`end_date`字段
  - 示例：辉夜大小姐想让我告白，显示为"2025-12-28 - 2026-01-01"
- 🔄 **进行中项目** (`in_progress`): 只保留`start_date`字段
- 📋 **愿望清单** (`wishlist`): 只保留`start_date`字段作为添加日期
- 📝 更新了字段说明文档

#### 2. 前端组件更新 (`src/components/ListCollections.vue`)
- ➕ 新增`formatDate()`函数处理日期显示逻辑
- 🔄 向后兼容：同时支持新的`start_date/end_date`和旧的`date`字段
- 📅 智能日期显示：
  - `completed`: 显示日期范围 (start_date - end_date)
  - `in_progress/wishlist`: 显示开始日期

## 🚀 优势

1. **更丰富的日期信息**：可以追踪项目的完整时间周期
2. **更好的用户体验**：清晰显示项目完成时间段
3. **向后兼容**：不会破坏现有的数据格式
4. **可扩展性**：为未来可能的日期分析功能奠定基础

## 🧪 测试建议

1. 检查已完成项目的日期范围显示
2. 验证进行中和愿望清单项目的日期显示
3. 确认响应式布局正常工作
4. 测试深色/浅色主题下的显示效果

## 📋 部署注意

此修改需要重新部署网站以使新的数据结构生效。